### PR TITLE
Update Conan.cmake

### DIFF
--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -8,10 +8,10 @@ macro(run_conan)
   include(${CMAKE_BINARY_DIR}/conan.cmake)
 
   conan_add_remote(
-    NAME
-    bincrafters
-    URL
-    https://api.bintray.com/conan/bincrafters/public-conan)
+            NAME
+            conan-center
+            URL
+            https://center.conan.io )
 
   conan_cmake_run(
     REQUIRES


### PR DESCRIPTION
bintray is depreciate for conan It is replaced by https://center.conan.io
see depreciation from conan blog 
[](https://blog.conan.io/2021/09/03/conancenter-declare-bintray-obsolete.html)